### PR TITLE
Add a no-screen option for CI tests

### DIFF
--- a/emitters.py
+++ b/emitters.py
@@ -72,7 +72,7 @@ class Emitter(LoggingEmitter):
         return answer
 
 
-class SimpleEmitter(NoopEmitter):
+class SimpleEmitter(LoggingEmitter):
     def clear(self):
         sys.stdout.write('-----------------------------------------------\n')
 

--- a/emitters.py
+++ b/emitters.py
@@ -24,16 +24,18 @@ class NoopEmitter(object):
         return None
 
 
-class Emitter(NoopEmitter):
-    def clear(self):
-        self.output.clear()
-
+class LoggingEmitter(NoopEmitter):
     def logger(self, logfile):
         if self.logfile:
             self.logfile.close()
         self.logfile = gzip.open(
             os.path.expanduser('~/.%s/%s.gz'
                                % (self.progname, logfile)), 'w')
+
+
+class Emitter(LoggingEmitter):
+    def clear(self):
+        self.output.clear()
 
     def emit(self, s):
         height, width = self.output.getmaxyx()
@@ -67,4 +69,24 @@ class Emitter(NoopEmitter):
         curses.echo()
         answer = self.output.getstr(height - 2, len(s) + 2)
         curses.noecho()
+        return answer
+
+
+class SimpleEmitter(NoopEmitter):
+    def clear(self):
+        sys.stdout.write('-----------------------------------------------\n')
+
+    def emit(self, s):
+        for line in s.split('\n'):
+            line = ''.join([i if ord(i) < 128 else ' ' for i in line])
+
+            if self.logfile:
+                self.logfile.write('%s %s\n' % (datetime.datetime.now(), line))
+                self.logfile.flush()
+
+            sys.stdout.write('%s\n' % line)
+            sys.stdout.flush()
+
+    def getstr(self, s):
+        answer = raw_input(s)
         return answer

--- a/ostrich
+++ b/ostrich
@@ -18,7 +18,6 @@
 import argparse
 import curses
 import datetime
-import fcntl
 import json
 import os
 import psutil
@@ -67,17 +66,21 @@ class Runner(object):
             self.load_step(step)
 
     def resolve_steps(self):
-        # Setup curses windows for the steps view
-        height, width = self.screen.getmaxyx()
-        progress = curses.newwin(3, width, 0, 0)
-        progress.border()
-        progress.refresh()
+        if not ARGS.no_curses:
+            # Setup curses windows for the steps view
+            height, width = self.screen.getmaxyx()
+            progress = curses.newwin(3, width, 0, 0)
+            progress.border()
+            progress.refresh()
 
-        output = curses.newwin(height - 4, width, 3, 0)
-        output.scrollok(True)
-        output.border()
-        output.refresh()
-        emitter = emitters.Emitter(progname, output)
+            output = curses.newwin(height - 4, width, 3, 0)
+            output.scrollok(True)
+            output.border()
+            output.refresh()
+            emitter = emitters.Emitter(progname, output)
+        else:
+            output = None
+            emitter = emitters.SimpleEmitter(progname, output)
 
         for step_name in self.complete:
             if step_name in self.steps:
@@ -94,13 +97,14 @@ class Runner(object):
                 step = self.steps[step_name]
 
                 if not step.depends or self.complete.get(step.depends, False):
-                    progress.clear()
-                    progress.addstr(1, 3, '%s %d steps to run, running %s'
-                                    % (datetime.datetime.now(),
-                                       len(self.steps),
-                                       step_name))
-                    progress.border()
-                    progress.refresh()
+                    if not ARGS.no_curses:
+                        progress.clear()
+                        progress.addstr(1, 3, '%s %d steps to run, running %s'
+                                        % (datetime.datetime.now(),
+                                           len(self.steps),
+                                           step_name))
+                        progress.border()
+                        progress.refresh()
 
                     run.append(step_name)
                     emitter.clear()
@@ -122,7 +126,9 @@ class Runner(object):
 
 
 def main(screen):
-    screen.nodelay(False)
+    if not ARGS.no_curses:
+        screen.nodelay(False)
+
     r = Runner(screen)
 
     r.load_step(steps.SimpleCommandStep(
@@ -427,6 +433,9 @@ if __name__ == '__main__':
     parser.add_argument('--no-screen', dest='no_screen',
                         default=False, action='store_true',
                         help='Do not force me to use screen or tmux')
+    parser.add_argument('--no-curses', dest='no_curses',
+                        default=False, action='store_true',
+                        help='Do not use curses for the UI')
     ARGS, extras = parser.parse_known_args()
 
     # We really like persistent sessions
@@ -434,4 +443,7 @@ if __name__ == '__main__':
         if ('TMUX' not in os.environ) and ('STY' not in os.environ):
             sys.exit('Only run ostrich in a screen or tmux session please')
 
-    curses.wrapper(main)
+    if ARGS.no_curses:
+        main(None)
+    else:
+        curses.wrapper(main)

--- a/ostrich
+++ b/ostrich
@@ -425,10 +425,14 @@ if __name__ == '__main__':
     parser.add_argument('--configure-only', dest='configure_only',
                         default=False, action='store_true',
                         help='Stop after configuring OSA')
+    parser.add_argument('--no-screen', dest='no_screen',
+                        default=False, action='store_true',
+                        help='Do not force me to use screen or tmux')
     ARGS, extras = parser.parse_known_args()
 
     # We really like persistent sessions
-    if ('TMUX' not in os.environ) and ('STY' not in os.environ):
-        sys.exit('Only run ostrich in a screen or tmux session please')
+    if not ARGS.no_screen:
+        if ('TMUX' not in os.environ) and ('STY' not in os.environ):
+            sys.exit('Only run ostrich in a screen or tmux session please')
 
     curses.wrapper(main)

--- a/ostrich
+++ b/ostrich
@@ -125,7 +125,6 @@ def main(screen):
     screen.nodelay(False)
     r = Runner(screen)
 
-    # We really like screen around here
     r.load_step(steps.SimpleCommandStep(
             'apt-daily',
             ('while [ `ps -ef | grep apt.systemd.daily | '


### PR DESCRIPTION
The CI tests I am building run without a controlling terminal, which means screen can't be used. That said, they run in a batch processing system so if the process goes away we have bigger problems. Let users who know what they're doing skip the screen / tmux check on startup.